### PR TITLE
Add federation path alias to tsconfig

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,6 +7,7 @@ register(
       "@db/*": ["db/*"],
       "@config/*": ["config/*"],
       "@controllers/*": ["controllers/*"],
+      "@federation/*": ["federation/*"],
       "@middleware/*": ["middleware/*"],
       "@models/*": ["models/*"],
       "@routes/*": ["routes/*"],


### PR DESCRIPTION
Introduced a new path alias '@federation/*' in the TypeScript configuration to simplify imports from the federation directory.