### PR TITLE
Move Google OAuth config to central config file

### DIFF
--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -7,26 +7,31 @@ interface Config {
   nodeEnv: string;
   dbUrl: string;
   dbName: string;
-  dbConnectionRetryCount: number;
   domain: string;
   aws: {
     region: string;
     s3MediaBucket: string;
   };
+  googleClientId: string;
+  googleClientSecret: string;
+  googleRedirectUri: string;
 }
 
+/** PLEASE DO NOT HARD CODE SECRETS FOR THE DEFAULT VALUES */
 const config: Config = {
   port: Number(process.env.PORT) || 3000,
   nodeEnv: process.env.NODE_ENV || "development",
-  dbUrl: process.env.DB_URL || "mongodb+srv://chirp-admins:Tp8zV7mwJu2qFVrc@chirp-cluster-1.lftjwo3.mongodb.net/",
-  dbName: process.env.DB_NAME || "cindi",
-  dbConnectionRetryCount: Number(process.env.DB_CONNECTION_RETRY_COUNT) || 5,
-  domain: process.env.DOMAIN || "localhost:8000",
+  dbUrl: process.env.DB_URL || "",
+  dbName: process.env.DB_NAME || "",
+  domain: process.env.DOMAIN || "",
   aws: {
     region: process.env.AWS_REGION || "af-south-1",
     s3MediaBucket:
       process.env.S3_MEDIA_BUCKET || "group-5-mastodon-media-bucket",
   },
+  googleClientId: process.env.GOOGLE_CLIENT_ID || "",
+  googleClientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+  googleRedirectUri: process.env.GOOGLE_REDIRECT_URI || "",
 };
 
 export {config};

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -30,7 +30,7 @@ export async function verifyGoogleJwt(jwt: string): Promise<IGoogleIdTokenPayloa
     // verify jwt's signature and validate claims
     const { payload } = await jwtVerify<IGoogleIdTokenPayload>(jwt, JWKS, {
       issuer: 'https://accounts.google.com',
-      audience: process.env.GOOGLE_CLIENT_ID,
+      audience: config.googleClientId
     });
     return payload;
 
@@ -48,9 +48,9 @@ export async function getGoogleJwt(req: Request, res: Response) {
 
     const params = new URLSearchParams({
       code: code,
-      client_id: process.env.GOOGLE_CLIENT_ID!,
-      client_secret: process.env.GOOGLE_CLIENT_SECRET!,
-      redirect_uri: process.env.GOOGLE_REDIRECT_URI!,
+      client_id: config.googleClientId,
+      client_secret: config.googleClientSecret,
+      redirect_uri: config.googleRedirectUri,
       grant_type: "authorization_code",
     });
 


### PR DESCRIPTION
Google OAuth client ID, secret, and redirect URI are now sourced from the central config object instead of environment variables directly. This improves maintainability and consistency in configuration management.