### PR TITLE
Add update method to Mutex and refactor usage

### DIFF
--- a/server/src/db/mongo.ts
+++ b/server/src/db/mongo.ts
@@ -8,7 +8,7 @@ const isConnectedMutex = new Mutex(false);
 const connectionPromise = new Promise<void>((resolve, reject) => {
   mongo.once("connected", () => {
     console.log("Connected to MongoDB");
-    isConnectedMutex.with((isConnected) => {
+    isConnectedMutex.update((isConnected) => {
       isConnected = true;
       return isConnected;
     });
@@ -22,14 +22,14 @@ const connectionPromise = new Promise<void>((resolve, reject) => {
 });
 
 mongo.on("connected", () => {
-  isConnectedMutex.with((isConnected) => {
+  isConnectedMutex.update((isConnected) => {
     isConnected = true;
     return isConnected;
   });
 });
 
 mongo.on("disconnected", () => {
-  isConnectedMutex.with((isConnected) => {
+  isConnectedMutex.update((isConnected) => {
     isConnected = false;
     return isConnected;
   });
@@ -57,7 +57,7 @@ export async function retrieveCollection(
 }
 
 export async function disconnectFromMongo(): Promise<void> {
-  await isConnectedMutex.with(async (isConnected) => {
+  await isConnectedMutex.update(async (isConnected) => {
     await mongo.close();
     isConnected = false;
     return isConnected;

--- a/server/src/db/s3.ts
+++ b/server/src/db/s3.ts
@@ -5,7 +5,7 @@ import { Mutex } from "@utils/index.ts";
 const s3Client = new Mutex<S3Client | undefined>(undefined);
 
 export async function connectToS3() {
-    return s3Client.with((client) => {
+    return s3Client.update((client) => {
         if (!client) {
             client = new S3Client({ region: config.aws.region });
             console.log("Connected to S3");
@@ -20,10 +20,11 @@ export async function retrieveS3Client() {
 }
 
 export async function disconnectFromS3() {
-    return s3Client.with((client) => {
+    return s3Client.update((client) => {
         if (client) {
             client.destroy();
         }
+        return undefined;
     });
 }
 

--- a/server/src/utils/mutex.ts
+++ b/server/src/utils/mutex.ts
@@ -11,4 +11,10 @@ export class Mutex<T> {
   async with<R>(fn: (val: T) => Promise<R> | R): Promise<R> {
     return this.mutex.runExclusive(() => fn(this.value));
   }
+  
+  async update(fn: (val: T) => Promise<T> | T): Promise<void> {
+    await this.mutex.runExclusive(async() => {
+      this.value = await fn(this.value);
+    });
+  }
 }


### PR DESCRIPTION
Introduces a new update method to the Mutex class for safely updating the internal value. Refactors MongoDB and S3 connection management to use update instead of with, improving clarity and intent for state changes.